### PR TITLE
update cypress schematic npm package

### DIFF
--- a/end-to-end-testing.md
+++ b/end-to-end-testing.md
@@ -174,7 +174,7 @@ In case you do need a WebDriver-based framework, have a look at Webdriver.io ins
 
 ## Installing Cypress
 
-An easy way to add Cypress to an existing Angular CLI project is the [Cypress Angular Schematic](https://github.com/briebug/cypress-schematic).
+An easy way to add Cypress to an existing Angular CLI project is the [Cypress Angular Schematic](https://www.npmjs.com/package/@cypress/schematic).
 
 In your Angular project directory, run this shell command:
 


### PR DESCRIPTION
I think this is the current official schematic, at the time of this PR, was updated 6 days ago, whereas the briebug one was updated two months ago.